### PR TITLE
Print Airware AWS acct info along with role

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,17 @@
 
 Authenticates a user against Okta and then uses the resulting SAML assertion to retrieve temporary STS credentials from AWS.
 
-This project is largely inspired by https://github.com/nimbusscale/okta_aws_login, but instead uses a purely API-driven approach, instead of parsing HTML during the authentication phase.
-
-Parsing the HTML is still required to get the SAML assertion, after authentication is complete. However, since we only need to look for the SAML assertion in a single, predictable tag, `<input name="SAMLResponse"...`, the results are a lot more stable across any changes that Okta may make to their interface.
-
 
 ## Installation
 
-- `pip install okta-awscli`
+- `virtualenv oktaawscli`
+- `source ./oktaawscli/bin/activate`
+- `pip install git+ssh://git@github.com/airware/okta-awscli.git`
 - Configure okta-awscli via the `~/.okta-aws` file with the following parameters:
 
 ```
 [default]
-base-url = <your_okta_org>.okta.com
+base-url = airware.okta.com
 
 ## The remaining parameters are optional.
 ## You will be prompted for them, if they're not included here.
@@ -22,19 +20,6 @@ username = <your_okta_username>
 password = <your_okta_password> # Only save your password if you know what you are doing!
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 ```
-
-## Supported Features
-
-- Tenant wide MFA support
-- Okta Verify [Play Store](https://play.google.com/store/apps/details?id=com.okta.android.auth) | [App Store](https://itunes.apple.com/us/app/okta-verify/id490179405)
-- Okta Verify Push Support
-- Google Authenticator [Play Store](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2) | [App Store](https://itunes.apple.com/us/app/google-authenticator/id388497605) 
-
-
-## Unsupported Features
-
-- Per application MFA support
-
 
 ## Usage
 

--- a/oktaawscli/airware_aws_accts.py
+++ b/oktaawscli/airware_aws_accts.py
@@ -1,0 +1,6 @@
+aws_acct_ids = {
+"214264291550" : "airware-midgard",
+"424780977340" : "airware-prod",
+"209840362042" : "airware-engdev",
+"952322697445" : "airware-org"
+}

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -8,6 +8,7 @@ from configparser import RawConfigParser
 import boto3
 from botocore.exceptions import ClientError
 
+from oktaawscli.airware_aws_accts import aws_acct_ids
 
 class AwsAuth(object):
     """ Methods to support AWS authentication using STS """
@@ -45,6 +46,7 @@ class AwsAuth(object):
 
         for index, role in enumerate(roles):
             role_name = role.role_arn.split('/')[1]
+            account_id = role.role_arn.split(':')[4]
 
             # Return the role as soon as it matches the saved role
             # Proceed to user choice if it's not found.
@@ -52,7 +54,10 @@ class AwsAuth(object):
                 if role_name == self.role:
                     self.logger.info("Using predefined role: %s" % self.role)
                     return roles[index]
-            role_list.append("%d: %s" % (index + 1, role_name))
+            try:
+                role_list.append("%d: %s %s" % (index + 1, role_name, aws_acct_ids[account_id]))
+            except KeyError:
+                role_list.append("%d: %s %s" % (index + 1, role_name, account_id))
 
         if self.role:
             self.logger.info("Predefined role, %s, not found in the list of roles assigned to you."

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -189,13 +189,16 @@ class OktaAuth(object):
             sys.exit(1)
 
         aws_apps = sorted(aws_apps, key=lambda app: app['sortOrder'])
-        print("Available apps:")
-        for index, app in enumerate(aws_apps):
-            app_name = app['label']
-            print("%d: %s" % (index + 1, app_name))
+        if len(aws_apps) > 1:
+            print("Available apps:")
+            for index, app in enumerate(aws_apps):
+                app_name = app['label']
+                print("%d: %s" % (index + 1, app_name))
 
-        app_choice = input('Please select AWS app: ') - 1
-        return aws_apps[app_choice]['label'], aws_apps[app_choice]['linkUrl']
+            app_choice = input('Please select AWS app: ') - 1
+            return aws_apps[app_choice]['label'], aws_apps[app_choice]['linkUrl']
+        else:
+            return aws_apps[0]['label'], aws_apps[0]['linkUrl']
 
     def get_saml_assertion(self, html):
         """ Returns the SAML assertion from HTML """


### PR DESCRIPTION
When choosing an aws saml role to assume print the respective airware aws
account name