### PR TITLE
redbird AWS accounts and clean output

### DIFF
--- a/oktaawscli/airware_aws_accts.py
+++ b/oktaawscli/airware_aws_accts.py
@@ -1,6 +1,0 @@
-aws_acct_ids = {
-"214264291550" : "airware-midgard",
-"424780977340" : "airware-prod",
-"209840362042" : "airware-engdev",
-"952322697445" : "airware-org"
-}

--- a/oktaawscli/aws_accts_conf.py
+++ b/oktaawscli/aws_accts_conf.py
@@ -1,0 +1,12 @@
+aws_acct_ids = {
+    "214264291550" : "airware-midgard",
+    "424780977340" : "airware-prod",
+    "209840362042" : "airware-engdev",
+    "952322697445" : "airware-org",
+    "643234410993" : "redbirdcloud",
+    "660561296250" : "redbirdcloud-poc",
+    "173654048158" : "redbirdcloud-dev",
+    "713874034545" : "redbirdcloud-tst",
+    "192348933240" : "redbirdcloud-ppd",
+    "807657260869" : "redbirdcloud-prd"
+}

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -16,7 +16,7 @@ def get_credentials(aws_auth, okta_profile, profile,
     app_name, assertion = okta.get_assertion()
     app_name = app_name.replace(" ", "")
     role = aws_auth.choose_aws_role(assertion)
-    principal_arn, role_arn = role
+    principal_arn, role_arn, role_name, account_id, account_name = role
 
     sts_token = aws_auth.get_sts_token(role_arn, principal_arn, assertion)
     access_key_id = sts_token['AccessKeyId']


### PR DESCRIPTION
Added the list of redbird accounts and made the account / role selection a little cleaner ordered with the same logic than the website: per account / per role

So we come from:
```
Enter password: 
1: Data 173654048158
2: Developer-ReadOnly 807657260869
3: Limited-Admin 192348933240
4: Developer-ReadOnly 173654048158
5: Limited-Admin airware-prod
6: Data 807657260869
7: Developer 173654048158
8: Billing airware-prod
9: Administrator 192348933240
10: Developer-ReadOnly 192348933240
11: Developer-ReadOnly airware-engdev
12: Billing airware-midgard
13: Developer 807657260869
14: Billing airware-org
15: Developer-ReadOnly airware-midgard
16: Limited-Admin 807657260869
17: Developer-ReadOnly airware-prod
18: Limited-Admin 173654048158
19: Administrator airware-midgard
20: Administrator 807657260869
21: Limited-Admin airware-engdev
22: Administrator 173654048158
23: Developer 192348933240
24: Data 192348933240
Please select the AWS role:
```

to:
```
Enter password: 
1:  airware-engdev   Developer-ReadOnly
2:  airware-engdev   Limited-Admin
3:  airware-midgard  Administrator
4:  airware-midgard  Billing
5:  airware-midgard  Developer-ReadOnly
6:  airware-org      Billing
7:  airware-prod     Billing
8:  airware-prod     Developer-ReadOnly
9:  airware-prod     Limited-Admin
10: redbirdcloud-dev Administrator
11: redbirdcloud-dev Data
12: redbirdcloud-dev Developer
13: redbirdcloud-dev Developer-ReadOnly
14: redbirdcloud-dev Limited-Admin
15: redbirdcloud-ppd Administrator
16: redbirdcloud-ppd Data
17: redbirdcloud-ppd Developer
18: redbirdcloud-ppd Developer-ReadOnly
19: redbirdcloud-ppd Limited-Admin
20: redbirdcloud-prd Administrator
21: redbirdcloud-prd Data
22: redbirdcloud-prd Developer
23: redbirdcloud-prd Developer-ReadOnly
24: redbirdcloud-prd Limited-Admin
Please select the AWS role:
```